### PR TITLE
logger.SetCallerSkip()

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,8 +20,9 @@ const (
 )
 
 var (
-	logger    *logrus.Logger
-	AllLevels = []Level{FatalLevel, ErrorLevel, WarnLevel, InfoLevel, DebugLevel}
+	logger     *logrus.Logger
+	AllLevels      = []Level{FatalLevel, ErrorLevel, WarnLevel, InfoLevel, DebugLevel}
+	callerSkip int = 10 // for prod(default), maybe 9 for test
 )
 
 func init() {
@@ -52,6 +53,10 @@ func SetFullpath(fullpath bool) {
 	})
 }
 
+func SetCallerSkip(skip int) {
+	callerSkip = skip
+}
+
 func getCallerPrettyfier(fullpath bool) func(f *runtime.Frame) (string, string) {
 	// https://github.com/sirupsen/logrus/blob/v1.9.0/example_custom_caller_test.go
 	// https://github.com/kubernetes/klog/blob/v2.90.1/klog.go#L644
@@ -66,7 +71,7 @@ func getCallerPrettyfier(fullpath bool) func(f *runtime.Frame) (string, string) 
 		}
 	}
 	return func(f *runtime.Frame) (string, string) {
-		_, file, line, ok := runtime.Caller(9)
+		_, file, line, ok := runtime.Caller(callerSkip)
 		if !ok {
 			file = "???"
 			line = 1

--- a/logger/logger_outer_test.go
+++ b/logger/logger_outer_test.go
@@ -2,6 +2,7 @@ package logger_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,6 +10,10 @@ import (
 	"github.com/kuoss/common/tester"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	logger.SetCallerSkip(9) // for go test
+}
 
 func TestSetLevel(t *testing.T) {
 	for _, level := range logger.AllLevels {
@@ -44,6 +49,40 @@ func TestSetFullpath(t *testing.T) {
 	})
 	t.Log(output)
 	assert.Regexp(t, `time="[^"]+" level=warning msg="hello=world number=42" file="logger_outer_test.go:[0-9]+"`, output)
+}
+
+func TestSetCallerSkip_outer(t *testing.T) {
+	testCases := []struct {
+		skip         int
+		wantContains string
+	}{
+		{0, `level=warning msg="hello=world number=42" file="logger.go:74"`},
+		{1, `level=warning msg="hello=world number=42" file="text_formatter.go:159"`},
+		{2, `level=warning msg="hello=world number=42" file="entry.go:289"`},
+		{3, `level=warning msg="hello=world number=42" file="entry.go:252"`},
+		{4, `level=warning msg="hello=world number=42" file="entry.go:304"`},
+		{5, `level=warning msg="hello=world number=42" file="entry.go:349"`},
+		{6, `level=warning msg="hello=world number=42" file="logger.go:154"`},
+		{7, `level=warning msg="hello=world number=42" file="logger.go:178"`},
+		{8, `level=warning msg="hello=world number=42" file="logger.go:98"`},
+		{9, `level=warning msg="hello=world number=42" file="logger_outer_test.go:80"`}, // good for go test
+		{10, `level=warning msg="hello=world number=42" file="logger_outer_test.go:91"`},
+		{11, `level=warning msg="hello=world number=42" file="logger_outer_test.go:79"`},
+		{12, `level=warning msg="hello=world number=42" file="testing.go:1576"`},
+		{13, `level=warning msg="hello=world number=42" file="asm_amd64.s:1598"`},
+		{14, `level=warning msg="hello=world number=42" file="???:1"`},
+		{15, `level=warning msg="hello=world number=42" file="???:1"`},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("skip=%d", tc.skip), func(t *testing.T) {
+			logger.SetCallerSkip(tc.skip)
+			got := captureOutput(func() {
+				logger.Warnf("hello=%s number=%d", "world", 42)
+			})
+			assert.Contains(t, got, tc.wantContains)
+		})
+	}
+	logger.SetCallerSkip(9)
 }
 
 func captureOutput(f func()) string {


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

현재 `callerSkip`이 `9`로 고정되어 있는데,
환경에 따라 맞지 않는 현상이 있었으며, go test에서는 `9`이, 라이브러리로서 사용할 때는 `10`이 적절한 것 같습니다.
상황에 따라 적절히 값을 설정할 수 있도록 `logger.SetCallerSkip(skip int)`을 도입하고자 합니다.

기본값은 `10`으로 하고, 테스트코드에서는 `9`를 사용하도록 하였습니다. ★

merge 후에는 `v0.1.4-beta.0`로 release하겠습니다.

#### Which issue(s) this PR fixes (관련 이슈):

- #6 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

- https://github.com/sirupsen/logrus/issues/972
